### PR TITLE
Implement basic posture reminder app

### DIFF
--- a/PostureApp/App.js
+++ b/PostureApp/App.js
@@ -1,20 +1,48 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import HomeScreen from './screens/HomeScreen';
+import SessionsScreen from './screens/SessionsScreen';
+import SettingsScreen from './screens/SettingsScreen';
+import { ThemeProvider, useTheme } from './theme';
+import { SettingsProvider, useSettings } from './SettingsContext';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { View } from 'react-native';
+import * as Notifications from 'expo-notifications';
 
-export default function App() {
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({ shouldShowAlert: true, shouldPlaySound: false, shouldSetBadge: false }),
+});
+
+const Tab = createBottomTabNavigator();
+
+function Tabs() {
+  const { colors } = useTheme();
   return (
-    <View style={styles.container}>
-      <Text>Open up App.js to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
+    <Tab.Navigator screenOptions={{ headerShown: false, tabBarActiveTintColor: colors.accent, tabBarStyle: { backgroundColor: colors.card } }}>
+      <Tab.Screen name="Home" component={HomeScreen} />
+      <Tab.Screen name="Sessions" component={SessionsScreen} />
+      <Tab.Screen name="Settings" component={SettingsScreen} />
+    </Tab.Navigator>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
+export default function App() {
+  return (
+    <SettingsProvider>
+      <InnerApp />
+    </SettingsProvider>
+  );
+}
+
+function InnerApp() {
+  const { settings } = useSettings();
+  return (
+    <ThemeProvider initial={settings.theme}>
+      <StatusBar style="auto" />
+      <NavigationContainer>
+        <Tabs />
+      </NavigationContainer>
+    </ThemeProvider>
+  );
+}

--- a/PostureApp/SettingsContext.js
+++ b/PostureApp/SettingsContext.js
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const SettingsContext = createContext();
+
+const defaultSettings = {
+  interval: 15,
+  stretch: true,
+  theme: 'system',
+};
+
+export function SettingsProvider({ children }) {
+  const [settings, setSettings] = useState(defaultSettings);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    AsyncStorage.getItem('settings').then(value => {
+      if (value) setSettings(JSON.parse(value));
+      setLoaded(true);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (loaded) {
+      AsyncStorage.setItem('settings', JSON.stringify(settings));
+    }
+  }, [settings, loaded]);
+
+  return (
+    <SettingsContext.Provider value={{ settings, setSettings }}>
+      {loaded && children}
+    </SettingsContext.Provider>
+  );
+}
+
+export function useSettings() {
+  return useContext(SettingsContext);
+}

--- a/PostureApp/app.json
+++ b/PostureApp/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {
       "image": "./assets/splash-icon.png",
@@ -24,6 +24,9 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      ["expo-notifications"]
+    ]
   }
 }

--- a/PostureApp/index.js
+++ b/PostureApp/index.js
@@ -1,3 +1,4 @@
+import 'react-native-gesture-handler';
 import { registerRootComponent } from 'expo';
 
 import App from './App';

--- a/PostureApp/package.json
+++ b/PostureApp/package.json
@@ -11,8 +11,14 @@
   "dependencies": {
     "expo": "~53.0.15",
     "expo-status-bar": "~2.2.3",
+    "expo-notifications": "~0.23.2",
     "react": "19.0.0",
-    "react-native": "0.79.4"
+    "react-native": "0.79.4",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "@react-navigation/native": "^6.1.7",
+    "@react-native-async-storage/async-storage": "^1.19.1",
+    "react-native-safe-area-context": "4.8.2",
+    "react-native-screens": "~3.30.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/PostureApp/screens/HomeScreen.js
+++ b/PostureApp/screens/HomeScreen.js
@@ -1,0 +1,169 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import * as Notifications from 'expo-notifications';
+import { useSettings } from '../SettingsContext';
+import { useTheme } from '../theme';
+import { addSession } from '../storage';
+
+export default function HomeScreen() {
+  const { settings } = useSettings();
+  const { colors } = useTheme();
+  const [running, setRunning] = useState(false);
+  const [start, setStart] = useState(null);
+  const [elapsed, setElapsed] = useState(0);
+  const [intervalId, setIntervalId] = useState(null);
+  const [paused, setPaused] = useState(false);
+  const [pauseStart, setPauseStart] = useState(null);
+  const [pausedTotal, setPausedTotal] = useState(0);
+  const [showStretch, setShowStretch] = useState(false);
+
+  useEffect(() => {
+    let id;
+    if (running && !paused) {
+      id = setInterval(() => {
+        const now = Date.now();
+        const diff = Math.floor((now - start - pausedTotal) / 1000);
+        setElapsed(diff);
+        if (settings.stretch && diff >= 7200) {
+          setShowStretch(true);
+        }
+      }, 1000);
+      setIntervalId(id);
+    }
+    return () => clearInterval(id);
+  }, [running, paused, start, pausedTotal, settings.stretch]);
+
+  const scheduleNotifications = async () => {
+    await Notifications.cancelAllScheduledNotificationsAsync();
+    await Notifications.scheduleNotificationAsync({
+      content: { title: 'Posture', body: 'Keep your back straight' },
+      trigger: { seconds: settings.interval * 60, repeats: true },
+    });
+    if (settings.stretch) {
+      await Notifications.scheduleNotificationAsync({
+        content: { title: 'Stretch time', body: 'Take a moment to stretch' },
+        trigger: { seconds: 7200, repeats: true },
+      });
+    }
+  };
+
+  const startSession = async () => {
+    const now = Date.now();
+    setStart(now);
+    setRunning(true);
+    setElapsed(0);
+    setPaused(false);
+    setPausedTotal(0);
+    setShowStretch(false);
+    scheduleNotifications();
+  };
+
+  const endSession = async () => {
+    if (!start) return;
+    const end = Date.now();
+    const duration = Math.floor((end - start - pausedTotal) / 1000);
+    await addSession({ start, end, duration });
+    await Notifications.cancelAllScheduledNotificationsAsync();
+    setRunning(false);
+    setStart(null);
+    setElapsed(0);
+  };
+
+  const toggleBreak = async () => {
+    if (!paused) {
+      setPaused(true);
+      setPauseStart(Date.now());
+      await Notifications.cancelAllScheduledNotificationsAsync();
+    } else {
+      const now = Date.now();
+      setPaused(false);
+      setPausedTotal(pausedTotal + (now - pauseStart));
+      scheduleNotifications();
+    }
+  };
+
+  const formatTime = (sec) => {
+    const h = Math.floor(sec / 3600);
+    const m = Math.floor((sec % 3600) / 60);
+    const s = sec % 60;
+    return [h, m, s]
+      .map(v => v.toString().padStart(2, '0'))
+      .join(':');
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      {!running ? (
+        <TouchableOpacity
+          style={[styles.startButton, { backgroundColor: colors.accent }]}
+          onPress={startSession}
+        >
+          <Text style={{ color: '#fff', fontWeight: 'bold' }}>Start Work</Text>
+        </TouchableOpacity>
+      ) : (
+        <>
+          <Text style={[styles.timer, { color: colors.text }]}>{formatTime(elapsed)}</Text>
+          <View style={styles.row}>
+            <TouchableOpacity
+              style={[styles.endButton, { backgroundColor: colors.danger }]}
+              onPress={endSession}
+            >
+              <Text style={{ color: '#fff' }}>End Session</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.breakButton, { backgroundColor: colors.card }]}
+              onPress={toggleBreak}
+            >
+              <Text style={{ color: colors.text }}>{paused ? 'Resume Work' : 'Take a Break'}</Text>
+            </TouchableOpacity>
+          </View>
+          {showStretch && (
+            <TouchableOpacity style={styles.stretchButton} onPress={() => setShowStretch(false)}>
+              <Text style={{ color: colors.text, marginBottom: 8 }}>Stretch Suggestions:</Text>
+              <Text style={{ color: colors.text }}>1. Neck rolls - gently roll your neck.</Text>
+              <Text style={{ color: colors.text }}>2. Shoulder shrugs - raise and release shoulders.</Text>
+              <Text style={{ color: colors.text }}>3. Back extensions - clasp hands and reach up.</Text>
+            </TouchableOpacity>
+          )}
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  startButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 16,
+    borderRadius: 8,
+  },
+  timer: {
+    fontSize: 48,
+    marginBottom: 20,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  endButton: {
+    padding: 12,
+    borderRadius: 8,
+    marginRight: 10,
+  },
+  breakButton: {
+    padding: 12,
+    borderRadius: 8,
+  },
+  stretchButton: {
+    marginTop: 20,
+    padding: 12,
+    backgroundColor: 'transparent',
+    alignItems: 'flex-start',
+  },
+});

--- a/PostureApp/screens/SessionsScreen.js
+++ b/PostureApp/screens/SessionsScreen.js
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, StyleSheet } from 'react-native';
+import { useTheme } from '../theme';
+import { getSessions } from '../storage';
+
+export default function SessionsScreen() {
+  const { colors } = useTheme();
+  const [sessions, setSessions] = useState([]);
+
+  useEffect(() => {
+    getSessions().then(setSessions);
+  }, []);
+
+  const renderItem = ({ item }) => {
+    const date = new Date(item.start);
+    const duration = Math.floor(item.duration / 60);
+    return (
+      <View style={[styles.item, { backgroundColor: colors.card }]}>
+        <Text style={{ color: colors.text }}>{date.toLocaleString()}</Text>
+        <Text style={{ color: colors.text }}>{duration} min</Text>
+      </View>
+    );
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <FlatList
+        data={sessions}
+        keyExtractor={(item, index) => index.toString()}
+        renderItem={renderItem}
+        ItemSeparatorComponent={() => <View style={{ height: 10 }} />}
+        contentContainerStyle={{ padding: 20 }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  item: { padding: 16, borderRadius: 8 },
+});

--- a/PostureApp/screens/SettingsScreen.js
+++ b/PostureApp/screens/SettingsScreen.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, Switch } from 'react-native';
+import { useTheme } from '../theme';
+import { useSettings } from '../SettingsContext';
+import { clearSessions } from '../storage';
+
+export default function SettingsScreen() {
+  const { colors } = useTheme();
+  const { settings, setSettings } = useSettings();
+
+  const setIntervalValue = (v) => setSettings({ ...settings, interval: v });
+  const toggleStretch = () => setSettings({ ...settings, stretch: !settings.stretch });
+  const setTheme = (t) => setSettings({ ...settings, theme: t });
+
+  const deleteData = async () => {
+    await clearSessions();
+  };
+
+  const intervalButton = (v, label) => (
+    <TouchableOpacity
+      style={[styles.option, { backgroundColor: settings.interval === v ? colors.card : 'transparent' }]}
+      onPress={() => setIntervalValue(v)}
+    >
+      <Text style={{ color: colors.text }}>{label}</Text>
+    </TouchableOpacity>
+  );
+
+  const themeButton = (t, label) => (
+    <TouchableOpacity
+      style={[styles.option, { backgroundColor: settings.theme === t ? colors.card : 'transparent' }]}
+      onPress={() => setTheme(t)}
+    >
+      <Text style={{ color: colors.text }}>{label}</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Text style={[styles.header, { color: colors.text }]}>Notification Interval</Text>
+      <View style={styles.row}>
+        {intervalButton(15, '15 min')}
+        {intervalButton(30, '30 min')}
+        {intervalButton(60, '1 hour')}
+      </View>
+
+      <View style={[styles.row, { marginTop: 20 }]}>
+        <Text style={{ color: colors.text, marginRight: 10 }}>Include Stretching</Text>
+        <Switch value={settings.stretch} onValueChange={toggleStretch} />
+      </View>
+
+      <Text style={[styles.header, { color: colors.text, marginTop: 20 }]}>Theme</Text>
+      <View style={styles.row}>
+        {themeButton('light', 'Light')}
+        {themeButton('dark', 'Dark')}
+        {themeButton('system', 'Use Device')}
+      </View>
+
+      <TouchableOpacity style={[styles.deleteButton, { backgroundColor: colors.danger }]} onPress={deleteData}>
+        <Text style={{ color: '#fff' }}>Delete Data</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20 },
+  header: { fontSize: 18, marginBottom: 10 },
+  row: { flexDirection: 'row', alignItems: 'center' },
+  option: { padding: 10, borderRadius: 8, marginRight: 10 },
+  deleteButton: { marginTop: 40, padding: 12, borderRadius: 8, alignSelf: 'flex-start' },
+});

--- a/PostureApp/storage.js
+++ b/PostureApp/storage.js
@@ -1,0 +1,17 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export async function addSession(session) {
+  const data = await AsyncStorage.getItem('sessions');
+  const sessions = data ? JSON.parse(data) : [];
+  sessions.push(session);
+  await AsyncStorage.setItem('sessions', JSON.stringify(sessions));
+}
+
+export async function getSessions() {
+  const data = await AsyncStorage.getItem('sessions');
+  return data ? JSON.parse(data) : [];
+}
+
+export async function clearSessions() {
+  await AsyncStorage.removeItem('sessions');
+}

--- a/PostureApp/theme.js
+++ b/PostureApp/theme.js
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { Appearance } from 'react-native';
+
+export const ThemeContext = createContext();
+
+const lightColors = {
+  background: '#FFFFFF',
+  text: '#000000',
+  card: '#F2F2F2',
+  border: '#DDDDDD',
+  accent: '#FF9500',
+  danger: '#FF3B30',
+};
+
+const darkColors = {
+  background: '#000000',
+  text: '#FFFFFF',
+  card: '#1C1C1E',
+  border: '#2C2C2E',
+  accent: '#FF9500',
+  danger: '#FF453A',
+};
+
+export function ThemeProvider({ children, initial }) {
+  const [theme, setTheme] = useState(initial || 'system');
+  const [colors, setColors] = useState(lightColors);
+
+  useEffect(() => {
+    const scheme = Appearance.getColorScheme();
+    if (theme === 'system') {
+      setColors(scheme === 'dark' ? darkColors : lightColors);
+    } else {
+      setColors(theme === 'dark' ? darkColors : lightColors);
+    }
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ colors, theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}


### PR DESCRIPTION
## Summary
- set up navigation, theme provider, and settings storage
- implement home timer screen with notification scheduling
- list stored sessions in a history tab
- add settings screen to configure reminder interval, stretching and theme
- include expo-notifications plugin

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864709c8b88832f94e060b9a191025d